### PR TITLE
Adding `timeout_multiplier` as global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ default `vktest_config.yaml`.
 The fields of the configuration file are:
  * `target_nodes` (*list of strings*), the Kubernetes names of the target nodes to be tested
  * `required_namespaces` (*optional list of strings*), a list of namespace that should exist before other tests are run
+ * `timeout_multiplier` (*optional float*), a multiplier for all the timeouts of the test. 
+   It can be increased for unattended testing or lowered during debug with cached images on the remote target.
  * `values` (*dictionary*) a dictionary of values passed *as-is* to the jinja2 template
 
 An example of configuration is reported below.
@@ -124,6 +126,8 @@ required_namespaces:
   - default
   - kube-system
   - interlink4
+
+timeout_multiplier: 1.
 
 values:
   namespace: interlink4

--- a/vktest_config.yaml
+++ b/vktest_config.yaml
@@ -1,10 +1,15 @@
 target_nodes: 
   - vk-hub-test-agent-1
+  - kueue-node
 
 required_namespaces:
   - default
   - kube-system
   - interlink4
+  - interlink-v
+  - interlink-k
+
+timeout_multiplier: 1
 
 values:
   namespace: interlink4

--- a/vktestset/ConfigManager.py
+++ b/vktestset/ConfigManager.py
@@ -12,6 +12,7 @@ TemplateKey = Literal[
 class ConfigManager (BaseModel, extra='forbid'):
    required_namespaces: List[str] = Field([])
    target_nodes: List[str] = Field([])
+   timeout_multiplier: float = 1.
    values: Dict[TemplateKey, Any]
 
    @staticmethod

--- a/vktestset/ValidationProcedure.py
+++ b/vktestset/ValidationProcedure.py
@@ -179,14 +179,15 @@ class ValidationProcedure(BaseModel, extra='forbid'):
         
         return ValidationProcedure(**dictionary)
 
-    def execute(self):
+    def execute(self, timeout_multiplier: float = 1.):
         """
         Perform the tests.
         """
         start_time = datetime.now()
         succeeded = False
         try:
-            while (datetime.now() - start_time).total_seconds() < self.timeout_seconds:
+            timeout = timeout_multiplier * self.timeout_seconds
+            while (datetime.now() - start_time).total_seconds() < timeout:
                 try:
                     with kubernetes_api() as k8s:
                         for check_pod in self.check_pods:

--- a/vktestset/basic_test.py
+++ b/vktestset/basic_test.py
@@ -59,5 +59,5 @@ def test_manifest(node, template):
             f.seek(0)
             create_from_yaml(k8s, f.name)
   
-    validation.execute()     
+    validation.execute(timeout_multiplier=cfg.timeout_multiplierr)     
 

--- a/vktestset/basic_test.py
+++ b/vktestset/basic_test.py
@@ -59,5 +59,5 @@ def test_manifest(node, template):
             f.seek(0)
             create_from_yaml(k8s, f.name)
   
-    validation.execute(timeout_multiplier=cfg.timeout_multiplierr)     
+    validation.execute(timeout_multiplier=cfg.timeout_multiplier)     
 


### PR DESCRIPTION
With slower networking, we observe random failures of the tests due to too severe timeout.

This PR adds a timeout_multiplier property to the global config which is used to multiply the timeout for all tests. 

The multiplier can be increase for unattended CI/CD tests, or decreased for plugin debugging with images cached on the target.

